### PR TITLE
Better chatban ingame message

### DIFF
--- a/crates/node/src/game/host/dispatch.rs
+++ b/crates/node/src/game/host/dispatch.rs
@@ -122,7 +122,7 @@ impl Dispatcher {
     let mut chat_banned_player_names = vec![];
     if !state.chat_banned_player_ids.is_empty() {
       for p in &state.chat_banned_player_ids {
-        chat_banned_player_names.push(state._player_name_lookup.get(&p).clone())
+        chat_banned_player_names.push(state._player_name_lookup.get(&p).cloned())
       }
       start_messages.push(format!("Some players in this game have been muted: {}", chat_banned_player_names.join(", ")));
     }

--- a/crates/node/src/game/host/dispatch.rs
+++ b/crates/node/src/game/host/dispatch.rs
@@ -119,8 +119,12 @@ impl Dispatcher {
     );
 
     let mut start_messages = vec![];
+    let mut chat_banned_player_names = vec![];
     if !state.chat_banned_player_ids.is_empty() {
-      start_messages.push("One or more players in this game have been muted.".to_string());
+      for p in &state.chat_banned_player_ids {
+        chat_banned_player_names.push(state._player_name_lookup.get(&p).clone())
+      }
+      start_messages.push(format!("Some players in this game have been muted: {}", chat_banned_player_names.join(", ")));
     }
 
     tokio::spawn(


### PR DESCRIPTION
I felt like it would be a good addition to display the names of muted players on game start, instead of just saying "Some players have been muted.". I tried my best to do a copycat of similar code, but I am not so sure about my Rust and hope I didn't make some stupid mistake (I guess testing would be very complicated, so I hope someone can review this).