### PR TITLE
Increase player list_ban PAGE_SIZE

### DIFF
--- a/crates/controller/src/player/db.rs
+++ b/crates/controller/src/player/db.rs
@@ -168,7 +168,7 @@ pub fn list_ban(
   query: Option<&str>,
   next_id: Option<i32>,
 ) -> Result<ListPlayerBan> {
-  const PAGE_SIZE: i64 = 100;
+  const PAGE_SIZE: i64 = 200;
   let mut q = player_ban::table
     .inner_join(player::table)
     .select(PlayerBan::COLUMNS)


### PR DESCRIPTION
When fetching ingame mutes for displaying on the website, only the 100 first mutes are displayed. This PR increases the limit to 200, which should be enough for a good while.