### PR TITLE
Add generic error propagation and CASC error handler

### DIFF
--- a/crates/client/src/message/messages.rs
+++ b/crates/client/src/message/messages.rs
@@ -75,6 +75,7 @@ pub enum OutgoingMessage {
   WatchGameError(ErrorMessage),
   WatchGameSetSpeedError(ErrorMessage),
   LanGameJoined(LanGameJoined),
+  GenericFloError(GenericFloError),
 }
 
 impl FromStr for IncomingMessage {
@@ -119,6 +120,29 @@ impl ErrorMessage {
       message: v.to_string(),
     }
   }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub enum GenericFloErrorCode {
+    Unknown = 0,
+    GamefilesCorrupted = 1,
+    ProcessAccessBlocked = 2,
+    NetworkAccessBlocked = 3,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct GenericFloError {
+    pub message: String,
+    pub code: GenericFloErrorCode,
+}
+
+impl GenericFloError {
+    pub fn new<T: ToString>(m: T, c: GenericFloErrorCode) -> Self {
+        GenericFloError {
+            message: m.to_string(),
+            code: c,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/client/src/message/session.rs
+++ b/crates/client/src/message/session.rs
@@ -8,6 +8,8 @@ use crate::controller::{
 };
 use crate::error::{Error, Result};
 use crate::message::stream::MessageStream;
+use crate::messages::GenericFloErrorCode;
+use crate::messages::GenericFloError;
 use crate::observer::{ObserverClient, ObserverHostShared};
 use crate::platform::{
   GetClientPlatformInfo, GetMapDetail, GetMapList, KillTestGame, Platform, PlatformStateError,
@@ -26,6 +28,7 @@ use s2_grpc_utils::S2ProtoPack;
 use std::sync::Arc;
 use tokio::sync::mpsc::{channel, Receiver, Sender, WeakSender};
 use tracing_futures::Instrument;
+use std::error::Error as StdError;
 
 #[derive(Debug)]
 pub struct Session {
@@ -183,14 +186,42 @@ impl Worker {
         self.send_frame::<PacketGameStartRequest>(req).await?;
       }
       IncomingMessage::StartTestGame(msg) => {
-        self
-          .platform
-          .send(crate::platform::StartTestGame {
-            name: msg.name,
-            outgoing_sender: reply_sender.downgrade(),
-          })
-          .await??;
-      }
+        let res = self
+            .platform
+            .send(crate::platform::StartTestGame {
+                name: msg.name,
+                outgoing_sender: reply_sender.downgrade(),
+            })
+            .await
+            .map_err(Error::from)
+            .and_then(|r| r);
+    
+        if let Err(err) = res {
+            if let Some(flo_w3map::error::Error::Storage(
+                flo_w3storage::error::Error::Casc(_),
+            )) = StdError::source(&err).and_then(|e| e.downcast_ref::<flo_w3map::error::Error>())
+            {
+                // Special handling for Casc errors:
+                tracing::error!("Error extracting WC3Map: {err}");
+                reply_sender
+                    .clone()
+                    .send(OutgoingMessage::GenericFloError(
+                        GenericFloError::new(err, GenericFloErrorCode::GamefilesCorrupted),
+                    ))
+                    .await?;
+            } else {
+                // Generic error handling:
+                tracing::error!("Unexpected error during StartTestGame: {err}");
+                reply_sender
+                    .clone()
+                    .send(OutgoingMessage::GenericFloError(
+                        GenericFloError::new(err, GenericFloErrorCode::Unknown),
+                    ))
+                    .await?;
+            }
+        }
+    }
+    
       IncomingMessage::KillTestGame => {
         self.platform.notify(KillTestGame).await?;
       }

--- a/crates/client/src/message/session.rs
+++ b/crates/client/src/message/session.rs
@@ -197,11 +197,9 @@ impl Worker {
             .and_then(|r| r);
     
         if let Err(err) = res {
-            if let Some(flo_w3map::error::Error::Storage(
-                flo_w3storage::error::Error::Casc(_),
-            )) = StdError::source(&err).and_then(|e| e.downcast_ref::<flo_w3map::error::Error>())
+            if let Some(flo_w3map::error::Error::Storage(_)) = StdError::source(&err).and_then(|e| e.downcast_ref::<flo_w3map::error::Error>())
             {
-                // Special handling for Casc errors:
+                // Special handling for Map storage errors:
                 tracing::error!("Error extracting WC3Map: {err}");
                 reply_sender
                     .clone()


### PR DESCRIPTION
Add a mechanism to communicate generic errors back to the client. 

Also adds handling of specific errors, like the CASC issues.