### PR TITLE
draft: feat(otel): add otel crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/observer-archiver",
   "crates/kinesis",
   "crates/replay",
+  "crates/otel",
 
   "crates/controller",
   "crates/node",

--- a/crates/otel/Cargo.toml
+++ b/crates/otel/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "flo-otel"
+version = "0.1.0"
+authors = ["Jonas Krüger Svensson <jonas-ks@hotmail.com>"]
+edition = "2021"
+
+[dependencies]
+tracing = { version = "0.1", default-features = false, features = ["log"]}
+tracing-core = {version = "0.1"}
+tracing-opentelemetry = { version = "0.30"  }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json"] }
+opentelemetry = { version = "0.29", features = ["trace"] }
+opentelemetry_sdk = { version = "0.29" }
+opentelemetry-semantic-conventions = { version = "0.29.0", features = ["semconv_experimental"]}
+# TODO: Use tonic instead of reqwest
+opentelemetry-otlp = { version = "0.29.0", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client", "reqwest-rustls"]}

--- a/crates/otel/src/builder.rs
+++ b/crates/otel/src/builder.rs
@@ -1,0 +1,136 @@
+use crate::otel::{init_tracing_subscriber, Config, OtelGuard};
+use opentelemetry::KeyValue;
+use opentelemetry_semantic_conventions::attribute::DEPLOYMENT_ENVIRONMENT_NAME;
+use opentelemetry_semantic_conventions::attribute::SERVICE_VERSION;
+use utils::environment::Environment;
+
+#[derive(Debug, Default)]
+pub struct OtelBuilder {
+    attributes: Vec<KeyValue>,
+    headers: Option<std::collections::HashMap<String, String>>,
+    project_name: Option<String>,
+    environment: Option<Environment>,
+}
+
+impl OtelBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            attributes: Vec::new(),
+            headers: None,
+            project_name: None,
+            environment: None,
+        }
+    }
+
+    pub fn set_token(mut self, token: String) -> Self {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("Authorization".into(), token);
+        self.headers = Some(headers);
+        self
+    }
+
+    pub fn set_project_name(mut self, name: String) -> Self {
+        self.project_name = Some(name);
+        self
+    }
+
+    pub fn set_version(mut self, version: String) -> Self {
+        self.attributes
+            .push(KeyValue::new(SERVICE_VERSION, version));
+        self
+    }
+
+    #[must_use]
+    pub fn set_environment(mut self, environment: Environment) -> Self {
+        self.environment = Some(environment.clone());
+        self.attributes.push(KeyValue::new(
+            DEPLOYMENT_ENVIRONMENT_NAME,
+            environment.to_string(),
+        ));
+        self
+    }
+
+    /// Can be used to set extra `attributes`
+    /// to your telemetry. E.g. `KeyValue::new(SERVICE_NAME, "my-service")`
+    pub fn set_attributes(mut self, attributes: &mut Vec<KeyValue>) -> Self {
+        self.attributes.append(attributes);
+        self
+    }
+
+    /// It's important that the guard is not dropped and must be assigned to a named variable
+    ///     let _guard = OtelBuilder::new()
+    //         .set_environment("dev".to_string())
+    //         .set_token("<my_token>".to_string())
+    //         .set_project_name(env!("CARGO_PKG_NAME").to_string())
+    //         .set_version(env!("CARGO_PKG_VERSION").to_string())
+    //         .build()
+    //         .unwrap();
+    ///
+    pub fn build(self) -> Result<OtelGuard, Box<dyn std::error::Error>> {
+        self.environment.ok_or("Environment not set")?;
+        let otel = Config {
+            headers: self.headers.ok_or("Header not set")?,
+            project_name: self.project_name.ok_or("Project name not set")?,
+            attributes: self.attributes,
+        };
+        Ok(init_tracing_subscriber(otel))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+
+    #[test]
+    fn test_ok() {
+        let guard = OtelBuilder::new()
+            .set_environment(Environment::Dev)
+            .set_token("token".to_string())
+            .set_project_name("project".to_string())
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_custom_attributes() {
+        let guard = OtelBuilder::new()
+            .set_environment(Environment::Dev)
+            .set_token("token".to_string())
+            .set_project_name("project".to_string())
+            .set_attributes(&mut vec![KeyValue::new(SERVICE_NAME, "test-service")]);
+        assert_eq!(
+            guard.attributes,
+            vec![
+                KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "dev"),
+                KeyValue::new(SERVICE_NAME, "test-service")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_missing() {
+        // env
+        assert!(OtelBuilder::new()
+            .set_token("token".to_string())
+            .set_project_name("project".to_string())
+            .set_attributes(&mut vec![KeyValue::new(SERVICE_NAME, "test-service")])
+            .build()
+            .is_err());
+        // token
+        assert!(OtelBuilder::new()
+            .set_environment(Environment::Dev)
+            .set_project_name("project".to_string())
+            .set_attributes(&mut vec![KeyValue::new(SERVICE_NAME, "test-service")])
+            .build()
+            .is_err());
+        // project name
+        assert!(OtelBuilder::new()
+            .set_token("token".to_string())
+            .set_environment(Environment::Dev)
+            .set_attributes(&mut vec![KeyValue::new(SERVICE_NAME, "test-service")])
+            .build()
+            .is_err());
+    }
+}

--- a/crates/otel/src/lib.rs
+++ b/crates/otel/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod builder;
+pub mod otel;

--- a/crates/otel/src/otel.rs
+++ b/crates/otel/src/otel.rs
@@ -1,0 +1,125 @@
+use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
+use opentelemetry_semantic_conventions::{
+    attribute::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_NAME},
+    SCHEMA_URL,
+};
+use std::collections::HashMap;
+use tracing_core::Level;
+use tracing_opentelemetry::{MetricsLayer, OpenTelemetryLayer};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use utils::environment::Environment;
+
+#[derive(Clone)]
+pub(crate) struct Config {
+    pub(crate) headers: HashMap<String, String>,
+    pub(crate) attributes: Vec<KeyValue>,
+    pub(crate) project_name: String,
+}
+
+// Create a Resource that captures information about the entity for which telemetry is recorded.
+fn resource(config: Config) -> Resource {
+    Resource::builder()
+        .with_service_name(config.project_name)
+        .with_attributes(config.attributes)
+        .build()
+}
+
+fn init_tracer_provider(config: Config) -> SdkTracerProvider {
+    // Build the OTLP span exporter using the tonic transport.
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        // TODO: Use tonic
+        .with_http()
+        .with_endpoint(
+            "<Grafana Cloud endpoint here>",
+        )
+        .with_headers(config.headers.clone())
+        .build()
+        .unwrap();
+
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource(config))
+        .build();
+
+    global::set_tracer_provider(tracer_provider.clone());
+
+    tracer_provider
+}
+
+// Construct MeterProvider for MetricsLayer
+fn init_meter_provider(config: Config) -> SdkMeterProvider {
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
+        .with_endpoint(
+            "<Grafana Cloud endpoint here>",
+        )
+        .with_headers(config.headers.clone())
+        .build()
+        .unwrap();
+
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(std::time::Duration::from_secs(30))
+        .build();
+
+    let meter_provider = MeterProviderBuilder::default()
+        .with_resource(resource(config))
+        .with_reader(reader)
+        .build();
+
+    global::set_meter_provider(meter_provider.clone());
+
+    meter_provider
+}
+
+/// Initialize tracing-subscriber and return OtelGuard for opentelemetry-related termination processing
+/// It's important to keep the guard in scope, even though it's not used for anything.
+/// Usage: `let _guard = init_tracing_subscriber(&config);`
+pub(crate) fn init_tracing_subscriber(config: Config) -> OtelGuard {
+    let tracer_provider = init_tracer_provider(config.clone());
+    let meter_provider = init_meter_provider(config);
+
+    let tracer = tracer_provider.tracer("net-rust");
+
+    tracing_subscriber::registry()
+        // The global level filter prevents the exporter network stack
+        // from reentering the globally installed OpenTelemetryLayer with
+        // its own spans while exporting, as the libraries should not use
+        // tracing levels below DEBUG. If the OpenTelemetry layer needs to
+        // trace spans and events with higher verbosity levels, consider using
+        // per-layer filtering to target the telemetry layer specifically,
+        // e.g. by target matching.
+        .with(tracing_subscriber::filter::LevelFilter::from_level(
+            Level::INFO,
+        ))
+        .with(tracing_subscriber::fmt::layer())
+        .with(MetricsLayer::new(meter_provider.clone()))
+        .with(OpenTelemetryLayer::new(tracer))
+        .init();
+
+    OtelGuard {
+        tracer_provider,
+        meter_provider,
+    }
+}
+
+pub struct OtelGuard {
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+}
+
+impl Drop for OtelGuard {
+    /// Call `shutdown` on the `TracerProvider` and `MeterProvider` when the guard is dropped.
+    /// Ensures that all spans and metrics are flushed before the process exits.
+    fn drop(&mut self) {
+        if let Err(err) = self.tracer_provider.shutdown() {
+            eprintln!("{err:?}");
+        }
+        if let Err(err) = self.meter_provider.shutdown() {
+            eprintln!("{err:?}");
+        }
+    }
+}


### PR DESCRIPTION
This adds a OTEL crate, which can be used as so:

```rust
#[tokio::main]
async fn main() {
    let _guard = OtelBuilder::new()
        .set_environment("prod".to_string())
        .set_token(<token>)
        .set_project_name(env!("CARGO_PKG_NAME").to_string())
        .set_version(env!("CARGO_PKG_VERSION").to_string())
        .build()
        .unwrap();

    <start gRPC server here>
}
```

Normal `tracing` can annotate any function:

```rust
#[tracing::instrument(ret, err, skip(packet))]
async fn foo(
    &self,
    packet: &Packet
) -> Result<(), io::Error> {
    tracing::info!(monotonic_counter.requests = 1); 
    let req_packet = req.get_packet();
    tracing::info!(
        packet = packet,
        "<- incoming request"
    );
}
```
