### PR TITLE
docs: add docker-compose and alternative INSTALL instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,11 @@ cargo install diesel_cli --no-default-features --features postgres
 
 ### Postgres configuration
 
-Set the postgres db user password
+> [!NOTE]
+> You can also use Docker - `docker-compose up -d postgres`. 
+> You still need to run `diesel setup` to create the schema. 
+
+1. Set the postgres db user password
 
 ```
 sudo -u postgres psql

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -225,6 +225,9 @@ If you receive an error saying something like ```multiple definition of `zlibVer
 
 ### Run flo-cli
 
+Ensure that the `FLO_CONTROLLER_SECRET` is set to the same value inserted into the `api_client` table earlier.  
+For local development, you can use the default value `1111`: `FLO_CONTROLLER_SECRET=1111 ./target/release/flo-cli`
+
 ```shell
 ./target/release/flo-cli server --help
 ./target/release/flo-cli server list-nodes

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  postgres:
+    container_name: flo_psql
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST_AUTH_METHOD: md5
+    image: postgres:13-alpine
+    volumes:
+      - database:/var/lib/postgresql/data
+    ports:
+      - '127.0.0.1:5432:5432'
+    restart: always
+
+  node:
+    container_name: flo-node
+    network_mode: host
+    build:
+      context: .
+      dockerfile: build/node.Dockerfile
+    depends_on:
+      - postgres
+    env_file:
+      - .env
+
+  controller:
+    container_name: flo-controller
+    build:
+      context: .
+      dockerfile: build/controller.Dockerfile
+    network_mode: host
+    depends_on:
+      - postgres
+      - node
+    env_file:
+      - .env
+
+volumes:
+  database:


### PR DESCRIPTION
Added a few docs to hurdles I stumbled over when getting this to run on MacOS. Also added a docker-compose. 

The rendered version can be viewed [here](https://github.com/JonasKs/flo/blob/docs_compose/INSTALL.md). 