### PR TITLE
Add warmup phase for ping collectors

### DIFF
--- a/crates/client/src/ping/collect.rs
+++ b/crates/client/src/ping/collect.rs
@@ -13,8 +13,10 @@ use tokio::time::sleep;
 const PACKETS: usize = 3;
 const TIMEOUT: Duration = Duration::from_secs(3);
 const INTERVAL: Duration = Duration::from_secs(60);
+const WARM_UP_PING_INTERVAL: Duration = Duration::from_secs(3);
 const ACTIVE_PING_INTERVAL: Duration = Duration::from_secs(10);
 const ERROR_DELAY: Duration = Duration::from_secs(60);
+const WARMUP_TIMEOUT: Duration = Duration::from_secs(45);
 
 pub struct PingCollectActor {
   sock_addr_string: String,
@@ -28,6 +30,7 @@ pub struct PingCollectActor {
   abort_timeout: Option<AbortHandle>,
   stats: PingStats,
   active: bool,
+  warming_up_abort: Option<AbortHandle>,
 }
 
 impl PingCollectActor {
@@ -44,11 +47,47 @@ impl PingCollectActor {
       abort_timeout: None,
       stats: PingStats::default(),
       active: false,
+      warming_up_abort: None,
+    }
+  }
+
+  // Check if the actor is currently warming up
+  pub fn is_warming_up(&self) -> bool {
+    self.warming_up_abort.is_some()
+  }
+
+  // Set the actor to warming up mode with automatic reset after timeout
+  fn start_warmup(&mut self, ctx: &mut Context<Self>) {
+    // Cancel any existing warmup timer
+    self.reset_warmup();
+
+    tracing::info!(address = self.address_str(), "starting warmup");
+
+    // Set up new timer
+    let addr = ctx.addr();
+    let (future, abort_handle) = abortable(async move {
+      sleep(WARMUP_TIMEOUT).await;
+      addr.notify(WarmupExpired).await.ok();
+    });
+
+    self.warming_up_abort = Some(abort_handle);
+    ctx.spawn(async {
+      future.await.ok();
+    });
+  }
+  
+  // Reset warming up state
+  fn reset_warmup(&mut self) {
+    if let Some(handle) = self.warming_up_abort.take() {
+      tracing::info!(address = self.address_str(), "stopping warmup");
+      handle.abort();
     }
   }
 
   fn interval(&self) -> Duration {
-    if self.active {
+    if self.is_warming_up() {
+      WARM_UP_PING_INTERVAL
+    } else if self.active {
       ACTIVE_PING_INTERVAL
     } else {
       INTERVAL
@@ -167,6 +206,12 @@ impl PingCollectActor {
 #[async_trait]
 impl Actor for PingCollectActor {
   async fn started(&mut self, ctx: &mut Context<Self>) {
+    // Due to the nature of how UDP is designed, we need to warm up with a recurring stream of messages
+    // until the stateful firewalls, anti viruses and NATs will actually allow the responses to pass back to us.
+    // As soon as we have sent enough pings to the server, we should hopefully receive the responses.
+    // This process will be aborted when we receive a valid response or after a certain timespan, whichever comes first.
+    // This ensures that we can reliably open the response channel without consistently hammering the server with pings.
+    self.start_warmup(ctx);
     self.start_ping(ctx);
   }
 }
@@ -285,6 +330,8 @@ impl Handler<PingReply> for PingCollectActor {
           current: finished.current,
           loss_rate: finished.loss_rate,
         };
+        // Reset warming up state after receiving all responses
+        self.reset_warmup();
         self.schedule_next(ctx, self.interval());
       }
     } else {
@@ -356,6 +403,24 @@ impl Handler<SetActive> for PingCollectActor {
   }
 }
 
+struct WarmupExpired;
+
+impl Message for WarmupExpired {
+  type Result = ();
+}
+
+#[async_trait]
+impl Handler<WarmupExpired> for PingCollectActor {
+  async fn handle(
+    &mut self,
+    _: &mut Context<Self>,
+    _: WarmupExpired,
+  ) {
+    tracing::warn!(address = self.address_str(), "Warmup period expired without being reset by a successful ping");
+    self.warming_up_abort = None;
+  }
+}
+
 #[tokio::test]
 #[ignore]
 async fn test_ping_collect() {
@@ -413,4 +478,35 @@ async fn test_ping_collect() {
 
   assert_eq!(stats.loss_rate, 0.0);
   assert!(stats.max.unwrap() <= 1);
+}
+
+#[tokio::test]
+async fn test_warming_up() {
+  use std::net::Ipv4Addr;
+  use tokio::sync::mpsc;
+  use tokio::time::sleep;
+
+  // Setup
+  let (tx, _) = mpsc::channel(1);
+  let sock_addr = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 3552));
+  let mut actor = PingCollectActor::new(tx, sock_addr);
+  let ctx = Context::new();
+  
+  // Initially not warming up
+  assert!(!actor.is_warming_up());
+  
+  // Start warmup
+  actor.start_warmup(&mut ctx);
+  assert!(actor.is_warming_up());
+  
+  // Manual reset
+  actor.reset_warmup();
+  assert!(!actor.is_warming_up());
+  
+  // Start warming up again
+  actor.start_warmup(&mut ctx);
+  assert!(actor.is_warming_up());
+  
+  // Testing auto-reset would require more complex async test setup
+  // which we'll skip for this simplified test
 }


### PR DESCRIPTION
Due to the nature of how UDP is designed, we need to warm up with a recurring stream of messages until the stateful firewalls, anti viruses and NATs will actually allow the responses to pass back to us.
As soon as we have sent enough pings to the server, we should hopefully receive the responses.
This process will be aborted when we receive a valid response or after a certain timespan, whichever comes first.
This ensures that we can reliably open the response channel without consistently hammering the server with pings.

Looks like this:
```2025-04-14T03:05:50.186635Z  INFO flo_client::controller: player session replaced: game_id = None player_id=771384
2025-04-14T03:05:50.187645Z  INFO flo_client::ping::collect: starting warmup address="40.127.64.115:3552"
2025-04-14T03:05:50.187643Z  INFO flo_client::ping::collect: starting warmup address="5.188.224.172:3552"
2025-04-14T03:05:50.188021Z  INFO flo_client::ping::collect: starting warmup address="20.194.31.191:3552"
2025-04-14T03:05:50.187645Z  INFO flo_client::ping::collect: starting warmup address="168.61.67.155:3552"
2025-04-14T03:05:50.188294Z  INFO flo_client::ping::collect: starting warmup address="92.38.189.146:3552"
2025-04-14T03:05:50.188433Z  INFO flo_client::ping::collect: starting warmup address="98.83.129.173:3552"
2025-04-14T03:05:50.188539Z  INFO flo_client::ping::collect: starting warmup address="106.75.251.204:3552"
2025-04-14T03:05:50.188190Z  INFO flo_client::ping::collect: starting warmup address="107.191.118.124:3552"
2025-04-14T03:05:50.188196Z  INFO flo_client::ping::collect: starting warmup address="104.211.182.11:3552"
2025-04-14T03:05:50.188070Z  INFO flo_client::ping::collect: starting warmup address="92.38.129.95:3552"
2025-04-14T03:05:50.188055Z  INFO flo_client::ping::collect: starting warmup address="5.189.201.152:3552"
2025-04-14T03:05:50.188318Z  INFO flo_client::ping::collect: starting warmup address="34.241.68.69:3552"
2025-04-14T03:05:50.188063Z  INFO flo_client::ping::collect: starting warmup address="5.188.36.67:3552"
2025-04-14T03:05:50.187672Z  INFO flo_client::ping::collect: starting warmup address="106.75.62.47:3552"
2025-04-14T03:05:50.187981Z  INFO flo_client::ping::collect: starting warmup address="23.100.3.159:3552"
2025-04-14T03:05:50.187969Z  INFO flo_client::ping::collect: starting warmup address="144.202.43.1:3552"
2025-04-14T03:05:50.188298Z  INFO flo_client::ping::collect: starting warmup address="34.102.69.232:3552"
2025-04-14T03:05:50.187863Z  INFO flo_client::ping::collect: starting warmup address="8.133.179.204:3552"
2025-04-14T03:05:50.187767Z  INFO flo_client::ping::collect: starting warmup address="20.195.188.185:3552"
2025-04-14T03:05:50.187681Z  INFO flo_client::ping::collect: starting warmup address="20.48.111.213:3552"
2025-04-14T03:05:50.188284Z  INFO flo_client::ping::collect: starting warmup address="195.133.53.4:3552"
2025-04-14T03:05:50.188434Z  INFO flo_client::ping::collect: starting warmup address="198.58.113.146:3552"
2025-04-14T03:05:50.188454Z  INFO flo_client::ping::collect: starting warmup address="35.198.253.236:3552"
2025-04-14T03:05:50.188474Z  INFO flo_client::ping::collect: starting warmup address="47.106.218.211:3552"
2025-04-14T03:05:50.188514Z  INFO flo_client::ping::collect: starting warmup address="202.144.195.240:3552"
2025-04-14T03:05:50.188254Z  INFO flo_client::ping::collect: starting warmup address="65.52.195.178:3552"
2025-04-14T03:05:50.188507Z  INFO flo_client::ping::collect: starting warmup address="20.218.100.27:3552"
```

And then as soon as we receive the first response (in my case immediately, for others maybe some time later), the warmup procedure gets stopped again:
```
2025-04-14T03:05:50.434294Z  INFO flo_client::ping::collect: stopping warmup address="20.218.100.27:3552"
2025-04-14T03:05:50.440406Z  INFO flo_client::ping::collect: stopping warmup address="34.241.68.69:3552"
2025-04-14T03:05:50.445116Z  INFO flo_client::ping::collect: stopping warmup address="5.188.224.172:3552"
2025-04-14T03:05:50.492358Z  INFO flo_client::ping::collect: stopping warmup address="5.188.36.67:3552"
2025-04-14T03:05:50.492362Z  INFO flo_client::ping::collect: stopping warmup address="23.100.3.159:3552"
2025-04-14T03:05:50.493273Z  INFO flo_client::ping::collect: stopping warmup address="195.133.53.4:3552"
2025-04-14T03:05:50.508116Z  INFO flo_client::ping::collect: stopping warmup address="98.83.129.173:3552"
2025-04-14T03:05:50.515107Z  INFO flo_client::ping::collect: stopping warmup address="144.202.43.1:3552"
2025-04-14T03:05:50.531469Z  INFO flo_client::ping::collect: stopping warmup address="198.58.113.146:3552"
2025-04-14T03:05:50.546849Z  INFO flo_client::ping::collect: stopping warmup address="92.38.129.95:3552"
2025-04-14T03:05:50.546862Z  INFO flo_client::ping::collect: stopping warmup address="65.52.195.178:3552"
2025-04-14T03:05:50.550080Z  INFO flo_client::ping::collect: stopping warmup address="92.38.189.146:3552"
2025-04-14T03:05:50.553889Z  INFO flo_client::ping::collect: stopping warmup address="107.191.118.124:3552"
2025-04-14T03:05:50.561715Z  INFO flo_client::ping::collect: stopping warmup address="34.102.69.232:3552"
2025-04-14T03:05:50.569831Z  INFO flo_client::ping::collect: stopping warmup address="168.61.67.155:3552"
2025-04-14T03:05:50.617278Z  INFO flo_client::ping::collect: stopping warmup address="20.195.188.185:3552"
2025-04-14T03:05:50.628942Z  INFO flo_client::ping::collect: stopping warmup address="104.211.182.11:3552"
2025-04-14T03:05:50.647898Z  INFO flo_client::ping::collect: stopping warmup address="40.127.64.115:3552"
2025-04-14T03:05:50.651532Z  INFO flo_client::ping::collect: stopping warmup address="35.198.253.236:3552"
2025-04-14T03:05:50.653762Z  INFO flo_client::ping::collect: stopping warmup address="202.144.195.240:3552"
2025-04-14T03:05:50.659153Z  INFO flo_client::ping::collect: stopping warmup address="20.194.31.191:3552"
2025-04-14T03:05:50.661640Z  INFO flo_client::ping::collect: stopping warmup address="20.48.111.213:3552"
2025-04-14T03:05:50.688788Z  INFO flo_client::ping::collect: stopping warmup address="106.75.251.204:3552"
2025-04-14T03:05:50.693196Z  INFO flo_client::ping::collect: stopping warmup address="106.75.62.47:3552"
2025-04-14T03:05:50.715173Z  INFO flo_client::ping::collect: stopping warmup address="47.106.218.211:3552"
```

and then some time later for the two servers that are offline:
```
2025-04-14T03:06:35.196832Z  WARN flo_client::ping::collect: Warmup period expired without being reset by a successful ping address="8.133.179.204:3552"
2025-04-14T03:06:35.196832Z  WARN flo_client::ping::collect: Warmup period expired without being reset by a successful ping address="5.189.201.152:3552"
```